### PR TITLE
Testing/14 integration testing

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_bloc: ^8.1.3
-  flutter_carousel_widget: ^2.1.0
   flutter_dotenv: ^5.1.0
   flutter_screenutil: 5.7.0
   get_it: 7.6.0
@@ -58,6 +57,9 @@ dev_dependencies:
     sdk: flutter
   json_serializable: 6.6.2
   flutter_lints: ^2.0.0
+  mockito: ^5.0.15
+  integration_test:
+    sdk: flutter
 
 flutter:
 

--- a/test/mocks/api_config/mock_api_config.dart
+++ b/test/mocks/api_config/mock_api_config.dart
@@ -1,0 +1,4 @@
+import 'package:mockito/annotations.dart';
+
+@GenerateNiceMocks([MockSpec<ApiConfig>()])
+import 'package:poke_app/core/shared/config/api_config.dart';

--- a/test/mocks/client/http/mock_http_client.dart
+++ b/test/mocks/client/http/mock_http_client.dart
@@ -1,0 +1,4 @@
+import 'package:mockito/annotations.dart';
+
+@GenerateNiceMocks([MockSpec<Client>()])
+import 'package:http/http.dart';

--- a/test/mocks/connectivity_checker/mock_connectivity_checker.dart
+++ b/test/mocks/connectivity_checker/mock_connectivity_checker.dart
@@ -1,0 +1,4 @@
+import 'package:mockito/annotations.dart';
+
+@GenerateNiceMocks([MockSpec<ConnectivityChecker>()])
+import 'package:poke_app/core/shared/config/connectivity_checker.dart';

--- a/test/mocks/environment_config/mock_environment_config.dart
+++ b/test/mocks/environment_config/mock_environment_config.dart
@@ -1,0 +1,4 @@
+import 'package:mockito/annotations.dart';
+
+@GenerateNiceMocks([MockSpec<EnvironmentConfig>()])
+import 'package:poke_app/core/shared/config/environment_config.dart';

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1,0 +1,13 @@
+export 'api_config/mock_api_config.dart';
+export 'api_config/mock_api_config.mocks.dart';
+export 'client/http/mock_http_client.dart';
+export 'client/http/mock_http_client.mocks.dart';
+export 'connectivity_checker/mock_connectivity_checker.dart';
+export 'connectivity_checker/mock_connectivity_checker.mocks.dart';
+export 'environment_config/mock_environment_config.dart';
+export 'environment_config/mock_environment_config.mocks.dart';
+export 'pokemon/mock_pokemon_repository.dart';
+export 'pokemon/mock_pokemon_repository.mocks.dart';
+export 'pokemon/mock_pokemon_service.dart';
+export 'pokemon/mock_pokemon_service.mocks.dart';
+

--- a/test/mocks/pokemon/mock_pokemon_repository.dart
+++ b/test/mocks/pokemon/mock_pokemon_repository.dart
@@ -1,0 +1,4 @@
+import 'package:mockito/annotations.dart';
+
+@GenerateNiceMocks([MockSpec<PokemonRepository>()])
+import 'package:poke_app/features/pokemon_list/data/repositories/implementation/pokemon_repository.dart';

--- a/test/mocks/pokemon/mock_pokemon_service.dart
+++ b/test/mocks/pokemon/mock_pokemon_service.dart
@@ -1,0 +1,4 @@
+import 'package:mockito/annotations.dart';
+
+@GenerateNiceMocks([MockSpec<PokemonService>()])
+import 'package:poke_app/features/pokemon_list/data/services/implementation/pokemon_service.dart';

--- a/test/models/pokemon_stub.dart
+++ b/test/models/pokemon_stub.dart
@@ -1,0 +1,41 @@
+import 'package:poke_app/features/pokemon_list/domain/entities/pokemon.dart';
+import 'package:poke_app/features/pokemon_list/domain/entities/pokemon_detail.dart';
+
+Pokemon pokemonStub = Pokemon(
+  name: 'squirtle',
+  url: 'https://pokeapi.co/api/v2/pokemon/7/',
+  imageUrl: '',
+  types: [
+    Type(
+      type: TypeName(
+        name: 'bug',
+      ),
+    ),
+  ],
+);
+
+PokemonDetail pokemonDetailStub = PokemonDetail(
+  name: 'squirtle',
+  height: 5,
+  moves: [
+    Moves(
+      move: Move(
+        name: 'electroweb',
+      ),
+    ),
+  ],
+  sprites: Sprites(frontDefault: 'sprites'),
+  types: [
+    Type(
+      type: TypeName(
+        name: 'bug',
+      ),
+    ),
+  ],
+  forms: [
+    Form(
+      url:
+          'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/7.png',
+    ),
+  ],
+);


### PR DESCRIPTION
### Integración de Paquetes de Pruebas y Creación de Mocks

En esta actualización, he integrado los paquetes `mockito` y `integration_test` para mejorar la cobertura y la precisión de las pruebas en la aplicación. Estos paquetes facilitan la creación de pruebas unitarias y de integración al permitir el uso de objetos simulados (mocks) y pruebas automatizadas que simulan el comportamiento de la aplicación en un entorno controlado.

#### Cambios Realizados:

1. **Integración de Paquetes de Pruebas:**
   - Se han añadido los paquetes `mockito` y `integration_test` al proyecto. Estos paquetes son esenciales para crear pruebas más efectivas y mantener la calidad del código a medida que se desarrollan nuevas funcionalidades.

2. **Creación de la Carpeta `mocks`:**
   - Se ha creado la carpeta `mocks` en el directorio de pruebas. Esta carpeta contiene los siguientes mocks básicos:
     - **`ApiConfig`**: Para simular la configuración de la API.
     - **`Client`**: Para simular las llamadas HTTP y respuestas.
     - **`ConnectivityChecker`**: Para simular la comprobación de la conexión a internet.
     - **`EnvironmentConfig`**: Para simular la configuración del entorno.
     - **`PokemonRepository`**: Para simular el repositorio de Pokemones.
     - **`PokemonService`**: Para simular los servicios relacionados con Pokemones.
   - **¿Por qué se hace esto?** La creación de estos mocks permite que las pruebas se realicen de manera aislada y confiable, sin depender de la infraestructura real o servicios externos. Esto asegura que los tests sean rápidos, estables y no se vean afectados por problemas externos o cambios en el entorno.

3. **Creación de Stubs para Modelos:**
   - Se han creado stubs para los modelos **`Pokemon`** y **`PokemonDetails`**. Estos stubs permiten simular el comportamiento de los modelos en las pruebas, facilitando la verificación de la lógica sin necesidad de implementar completamente los modelos.